### PR TITLE
Add support for EditorConfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,5 +1,16 @@
 # Developing Member Portal
 
+## EditorConfig
+
+> [EditorConfig](http://editorconfig.org) helps developers define and maintain consistent coding styles between different editors and IDEs.
+
+This project uses EditorConfig to maintain consistency. It is encouraged that all project participants enable EditorConfig support in their preferred editor. Support exists for most major editors today. Plugins for the most popular editors include:
+
+* [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime#readme)
+* [Atom](https://github.com/sindresorhus/atom-editorconfig#readme)
+* VS Code - _As of 2017 rc1 Visual Studio ships with `.editorconfig` support baked in_
+
+Plugins and support for many other editors can be found in the _[Download a Plugin](http://editorconfig.org/#download)_ section of the EditorConfig website.
 
 ## Rubocop, Guard and Your Editor
 


### PR DESCRIPTION
# Overview

> [EditorConfig](http://editorconfig.org) helps developers maintain consistent coding styles between different editors

This adds an initial EditorConfig configuration file to help ensure the consistency of inbound changes to the project.

Closes #48 

## Notes

It is encouraged that all project participants enable EditorConfig support in their preferred editor. Support exists for most major editors today. Plugins for the most popular editors include:

* [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime#readme)
* [Atom](https://github.com/sindresorhus/atom-editorconfig#readme)
* VS Code - _As of 2017 rc1 Visual Studio ships with .editorconfig support baked in_

Plugins and support for many other editors can be found in the [Download a Plugin](http://editorconfig.org/#download) section of the EditorConfig website. 