### PR TITLE
Add Gemnasium badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Member Portal
 
-[![Build Status](https://travis-ci.org/renocollective/member-portal.svg?branch=master)](https://travis-ci.org/renocollective/member-portal)
+[![Build Status](https://travis-ci.org/renocollective/member-portal.svg?branch=master)](https://travis-ci.org/renocollective/member-portal) [![Dependency Status](https://gemnasium.com/badges/github.com/renocollective/member-portal.svg)](https://gemnasium.com/github.com/renocollective/member-portal)
 
 This README would normally document whatever steps are necessary to get the
 application up and running.


### PR DESCRIPTION
This adds a README badge for the [Gemnasium project status](https://gemnasium.com/github.com/renocollective/member-portal), which shows the current state of the project dependencies. 

[![Dependency Status](https://gemnasium.com/badges/github.com/renocollective/member-portal.svg)](https://gemnasium.com/github.com/renocollective/member-portal)