### PR TITLE
Add `license_finder`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.4.2
 script:
   - bundle exec rails bundle:audit
+  - bundle exec license_finder --quiet
   - bundle exec rubocop
   - bundle exec rails test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ addons:
   postgresql: 9.6
 before_script:
   - bundle exec rails db:setup
-bundler_args: --jobs 4 --retry 3 --without development
+bundler_args: --jobs 4 --retry 3
 cache: bundler
 language: ruby
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'capybara', '~> 2.15'
   gem 'guard-minitest', '~> 2.4.6'
   gem 'guard-rubocop', '~> 1.3.0'
+  gem 'license_finder', '~> 3.0.4'
   gem 'rubocop', '~> 0.50.0', require: false
   gem 'selenium-webdriver'
   # Loads environment variables

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       guard (~> 2.0)
       rubocop (~> 0.20)
     highline (1.7.8)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -119,6 +121,13 @@ GEM
     json (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    license_finder (3.0.4)
+      bundler
+      httparty
+      rubyzip
+      thor
+      with_env (> 1.0)
+      xml-simple
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -137,6 +146,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
     net-http-persistent (3.0.0)
@@ -263,6 +273,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    with_env (1.1.0)
+    xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -279,6 +291,7 @@ DEPENDENCIES
   guard-minitest (~> 2.4.6)
   guard-rubocop (~> 1.3.0)
   jbuilder (~> 2.5)
+  license_finder (~> 3.0.4)
   listen (>= 3.0.5, < 3.2)
   mini_magick (= 4.8.0)
   puma (~> 3.10)

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,56 @@
+---
+- - :whitelist
+  - MIT
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:12:42.203797000 Z
+- - :whitelist
+  - Apache 2.0
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:13:13.743139000 Z
+- - :whitelist
+  - New BSD
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:13:29.251637000 Z
+- - :whitelist
+  - Simplified BSD
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:13:38.890911000 Z
+- - :whitelist
+  - ISC
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:13:50.459085000 Z
+- - :whitelist
+  - ruby
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:14:00.222870000 Z
+- - :whitelist
+  - Apache
+  - :who: Phil Cohen
+    :why: Permissive License
+    :versions: []
+    :when: 2017-09-23 04:14:20.402111000 Z
+- - :license
+  - bundler
+  - MIT
+  - :who: Phil Cohen
+    :why: https://github.com/bundler/bundler/blob/master/LICENSE.md
+    :versions: []
+    :when: 2017-09-23 04:15:11.571644000 Z
+- - :approve
+  - bundler-audit
+  - :who: Phil Cohen
+    :why: Approved development dependency
+    :versions: []
+    :when: 2017-09-23 04:20:13.685598000 Z


### PR DESCRIPTION
This adds [`license_finder`](https://github.com/pivotal/LicenseFinder) to verify licenses for dependencies added to the project. It is designed to be run when dependencies are added, and has been added to CI jobs. 

Closes #66 
