### PR TITLE
Refactor `config/secrets.yml`

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,2 @@
-# dotenv .env file for environment variables 
-#
-# each developer should make their own .env.local file using this .env file
-# as a guide
-#
-# .env.local files are not checked into the remote repo
-#
-# reference these attributes in code like this:
-# config.fog_directory  = ENV['S3_BUCKET']
-
-S3_BUCKET=bogus-key-for-example
+# Rails
+SECRET_KEY_BASE=insecure-secret_key_base

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,32 +1,15 @@
 # Be sure to restart your server when you modify this file.
 
-# Your secret key is used for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
+# defaults across all environments
+defaults: &defaults
+  secret_key_base: "<%= ENV.fetch("SECRET_KEY_BASE") %>"
 
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rails secret` to generate a secure secret key.
-
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
-
-# Shared secrets are available across all environments.
-
-# shared:
-#   api_key: a1B2c3D4e5F6
-
-# Environmental secrets are only available for that specific environment.
-
+# apply shared configuration to environments
 development:
-  secret_key_base: a907fda2809c6ddff11958889057679b3ec7c43796d5178f0abb7f724283612a4d5b2b43dd9d20927c5e07e23d78213297adcfb51cf04920c8fae4543b680c33
+  <<: *defaults
 
 test:
-  secret_key_base: 5986bafec15cf3db2cdea73b30f3f32fffe7e52a29fde6474c9ea339934873850e1434fe0af33b2e5d5859d916a7dfe7063bd11528e5e01c72c2359fcadf6b43
-
-# Do not keep production secrets in the unencrypted secrets file.
-# Instead, either read values from the environment.
-# Or, use `bin/rails secrets:setup` to configure encrypted secrets
-# and move the `production:` environment over there.
+  <<: *defaults
 
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  <<: *defaults


### PR DESCRIPTION
This adds a `defaults` key to reduce duplication and ease sharing of values between environments. This allows defining and `fetch`ing of values once in a common location. Individual secrets can be
overridden per environment by redefining the value below the `<<*` import.

This provides a foundation for #71 and #76 to build upon. 
