### PR TITLE
Remove development database URL from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 SECRET_KEY_BASE=insecure-secret_key_base
-DATABASE_URL=postgresql://localhost/member_portal_development
+DATABASE_URL=postgresql://insecure-database_url

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+SECRET_KEY_BASE=insecure-secret_key_base
+DATABASE_URL=postgresql://localhost/member_portal_test
+ALGOLIA_API_KEY=insecure-algolia_api_key
+ALGOLIA_APPLICATION_ID=insecure-algolia_application_id

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .bundle
 .byebug_history
 .env.local
+.env.test.local
 coverage
 db/*.sqlite3
 db/*.sqlite3-journal


### PR DESCRIPTION
The development database URL was set in .env and that meant the
development database was the default for all environments, including
test.  Although convenient for new contributors, it is confusing when
development database results are returned when tests run.  Also, it is
possible that local data might cause tests to fail or pass incorrectly.