### PR TITLE
Set BlockLength to 50 in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ AllCops:
 
 Metrics/LineLength:
   Max: 80
+
+BlockLength:
+  Max: 50


### PR DESCRIPTION
## Types of changes

Rubocop was limiting block lengths to 25 which is overly restrictive in places like the config/development.rb and config/production.rb.

* [x] Other

### Your checklist for this pull request

* [x] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [x] The commit's or even all commits' message styles matches our requested structure.
* [x] Have you added necessary documentation (if appropriate)?
