### PR TITLE
Add confirmation notice before deleting category

### DIFF
--- a/app/views/admin/categories/_collection.html.erb
+++ b/app/views/admin/categories/_collection.html.erb
@@ -80,7 +80,8 @@ to display a collection of resources in an HTML table.
             [namespace, resource],
             class: "text-color-red",
             method: :delete,
-            data: { confirm: t("administrate.actions.confirm") }
+            data: { confirm: "Deleting this category will delete all posts
+              associated with the category. Are you sure?" }
           ) if show_action? :destroy, resource %></td>
         <% end %>
       </tr>


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce (new feature, bug fix, front end, other)?
Bug fix.

### Description
Easy fix for when deleting categories by adding a confirmation pop up before deleting. Will look more into a permanent fix:)

### Your checklist for this pull request

* [x] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [x] The commit's or even all commits' message styles matches our requested structure.
* [x] Have you added necessary documentation (if appropriate)?
