### PR TITLE
Add slug to post model

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,6 +65,6 @@ class PostsController < ApplicationController
   end
 
   def find_post
-    @post = Post.find(params[:id])
+    @post = Post.find_by_slug(params[:slug])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,15 @@ class Post < ApplicationRecord
   belongs_to :member
   belongs_to :category
   has_many :comments, dependent: :destroy
+  before_create :create_slug
 
   validates :title, :content, :category_id, presence: true
+
+  def to_param
+    slug
+  end
+
+  def create_slug
+    self.slug = title.parameterize
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   resources :members, param: :username
   root to: 'home#index'
 
-  resources :posts do
+  resources :posts, param: :slug do
     resources :comments
     root to: 'posts#index'
   end

--- a/db/migrate/20180409213053_add_slug_to_post.rb
+++ b/db/migrate/20180409213053_add_slug_to_post.rb
@@ -1,0 +1,5 @@
+class AddSlugToPost < ActiveRecord::Migration[5.1]
+  def change
+    add_column :posts, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20180410052509) do
     t.datetime "updated_at", null: false
     t.bigint "member_id"
     t.bigint "category_id"
+    t.string "slug"
     t.index ["category_id"], name: "index_posts_on_category_id"
     t.index ["member_id"], name: "index_posts_on_member_id"
   end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -33,17 +33,17 @@ RSpec.describe PostsController, type: :controller do
   end
 
   it 'should show post' do
-    get :show, params: { id: post1.id }
+    get :show, params: { slug: post1.slug }
     expect(response).to have_http_status(200)
   end
 
   it 'should get edit' do
-    get :edit, params: { id: post1.id }
+    get :edit, params: { slug: post1.slug }
     expect(response).to have_http_status(200)
   end
 
   it 'should update post' do
-    patch :update, params: { id: post1.id, post: {} }
+    patch :update, params: { slug: post1.slug, post: {} }
     expect(response).to redirect_to(post_path(post1))
   end
 
@@ -51,7 +51,7 @@ RSpec.describe PostsController, type: :controller do
     post2 = create(:post)
     post1.touch
     before_count = Post.count
-    delete :destroy, params: { id: post1.id }
+    delete :destroy, params: { slug: post1.slug }
     expect(Post.count).to eq(before_count - 1)
     expect(response).to redirect_to(posts_path)
     expect(post2).to be_persisted


### PR DESCRIPTION
## Types of changes

Adds a friendly slug to posts. Such as /posts/hello-world.

Will require a database migration in dev and test.

### Your checklist for this pull request

* [x] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [x] The commit's or even all commits' message styles matches our requested structure.
* [x] Have you added necessary documentation (if appropriate)?
