### PR TITLE
Added rake task to create first admin account

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ bundle exec rails db:setup
 bundle exec rails db:migrate
 ```
 
+Before we start the server, we will create our first admin user. This will ask you for information for your first user account that will have admin access. You can edit this user and grant other users admin privileges once the server has started.
+```shell
+bundle exec rake setupadmin
+```
+
 To start and run the rails application:
 ```shell
 rails s

--- a/lib/tasks/setupadmin.rake
+++ b/lib/tasks/setupadmin.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'io/console'
+
+desc 'Setup first admin user'
+task setupadmin: [:environment] do
+  if Member.count.zero?
+    puts 'Please enter an EMAIL ADDRESS for your admin user:'
+    email = STDIN.gets.chomp
+
+    puts 'Please enter a USERNAME for your admin user:'
+    username = STDIN.gets.chomp
+
+    puts 'Please enter a PASSWORD for your admin user:'
+    password = STDIN.noecho(&:gets).chomp
+
+    # Create admin user
+    @admin = Member.create(
+      username: username,
+      firstname: 'Admin',
+      lastname: 'Admin',
+      email: email,
+      password: password,
+      password_confirmation: password,
+      admin: true
+    )
+
+    # Create initial category
+    Category.create(
+      name: 'Uncategorized'
+    )
+
+    puts 'Your admin user has been created. You can sign in once the server is started!'
+  else
+    puts 'Users have already been created for this Member Portal.'
+  end
+end

--- a/lib/tasks/setupadmin.rake
+++ b/lib/tasks/setupadmin.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'io/console'
 
 desc 'Setup first admin user'
@@ -29,7 +30,7 @@ task setupadmin: [:environment] do
       name: 'Uncategorized'
     )
 
-    puts 'Your admin user has been created. You can sign in once the server is started!'
+    puts 'Your admin user has been created. You can sign in with this account.'
   else
     puts 'Users have already been created for this Member Portal.'
   end


### PR DESCRIPTION
Addition of a rake task to create first admin and first category but only if no other members have been created. If members exist, the setup exits.


### Your checklist for this pull request

* [x] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [x] The commit's or even all commits' message styles matches our requested structure.
* [x] Have you added necessary documentation (if appropriate)?
