### PR TITLE
Removed ruby 2.4.2 from .travis.yml as we have defined 2.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
   email: false
 rvm:
   - 2.3.5
-  - 2.4.2
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter


### PR DESCRIPTION
## Types of changes

Limiting our CI in Travis to just 2.3.5 at the moment. Defining the ruby version in the Gemfile causes Ci to fail when on another version. If we want to move to 2.4.2 in the future, we can do so and update it in Gemfile, .travis.yml and .ruby-version.

### Your checklist for this pull request

* [x] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [x] The commit's or even all commits' message styles matches our requested structure.
* [x] Have you added necessary documentation (if appropriate)?
