### PR TITLE
Add break to code instruction

### DIFF
--- a/docs/MAILER.md
+++ b/docs/MAILER.md
@@ -7,6 +7,7 @@ For development, we are using a local SMTP server called [Mailcatcher](https://g
 You will need to install Mailcatcher and run it. The settings for using the local SMTP server are already setup in `/config/environments/development.rb`.
 
 > gem install mailcatcher
+
 > mailcatcher
 
 


### PR DESCRIPTION
## Types of changes

This fix separates the two Mailcatcher commands from one line to two.


### Description

The current markdown document shows the command as `gem install mailcatcher mailcatcher`.  This fix puts the two commands on two lines.

### Your checklist for this pull request

* [X] Have you followed the guidelines in our [Contributing](https://github.com/renocollective/member-portal/blob/master/CONTRIBUTING.md) document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/renocollective/member-portal/pulls) for the same update/change?
* [X] The commit's or even all commits' message styles matches our requested structure.
* [X] Have you added necessary documentation (if appropriate)?
